### PR TITLE
Made CCEtcdClient public

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ccentral-parent</artifactId>
         <groupId>io.github.slvwolf</groupId>
-        <version>0.5.0</version>
+        <version>0.5.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -19,13 +19,13 @@
         <dependency>
             <groupId>io.github.slvwolf</groupId>
             <artifactId>ccentral-common</artifactId>
-            <version>0.5.0</version>
+            <version>0.5.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.github.slvwolf</groupId>
             <artifactId>ccentral-etcd</artifactId>
-            <version>0.5.0</version>
+            <version>0.5.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ccentral-parent</artifactId>
         <groupId>io.github.slvwolf</groupId>
-        <version>0.5.0</version>
+        <version>0.5.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/etcd/pom.xml
+++ b/etcd/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ccentral-parent</artifactId>
         <groupId>io.github.slvwolf</groupId>
-        <version>0.5.0</version>
+        <version>0.5.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>io.github.slvwolf</groupId>
             <artifactId>ccentral-common</artifactId>
-            <version>0.5.0</version>
+            <version>0.5.1</version>
             <scope>compile</scope>
         </dependency>
 

--- a/etcd/src/main/java/io/github/slvwolf/CCEtcdClient.java
+++ b/etcd/src/main/java/io/github/slvwolf/CCEtcdClient.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-class CCEtcdClient implements CCClient {
+public class CCEtcdClient implements CCClient {
 
   private static final String CLIENT_VERSION = "java_etcd-0.5.0";
   private static final int METRIC_INTERVAL = 40;
@@ -73,11 +73,11 @@ class CCEtcdClient implements CCClient {
     CCEtcdClient.LOG = logger;
   }
 
-  Clock getClock() {
+  public Clock getClock() {
     return clock;
   }
 
-  void setClock(Clock clock) {
+  public void setClock(Clock clock) {
     this.clock = clock;
   }
 

--- a/etcd/src/main/java/io/github/slvwolf/CCEtcdClient.java
+++ b/etcd/src/main/java/io/github/slvwolf/CCEtcdClient.java
@@ -22,7 +22,7 @@ import java.util.UUID;
 
 public class CCEtcdClient implements CCClient {
 
-  private static final String CLIENT_VERSION = "java_etcd-0.5.0";
+  private static final String CLIENT_VERSION = "java_etcd-0.5.1";
   private static final int METRIC_INTERVAL = 40;
   private int configCheckInterval = 40;
   private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.slvwolf</groupId>
     <artifactId>ccentral-parent</artifactId>
     <!-- Remember to increment version number in class as well -->
-    <version>0.5.0</version>
+    <version>0.5.1</version>
     <modules>
         <module>common</module>
         <module>etcd</module>


### PR DESCRIPTION
Made `CCEtcdClient` class public so it can actually be used in other projects directly.

Currently it cannot be used in other namespaces due to the class having package-level visibility.